### PR TITLE
feat: 대시보드 섹션 컴포넌트 추가 및 페이지 레이아웃 개선

### DIFF
--- a/src/components/Dashboard/OrderStatus.jsx
+++ b/src/components/Dashboard/OrderStatus.jsx
@@ -1,0 +1,13 @@
+import CardItem from '../share/CardItem';
+export default function OrderStatus() {
+  return (
+    <>
+      <div className='grid grid-cols-2 gap-2 h-1/3'>
+        <CardItem title='메뉴 (진행중)' className='overflow-auto'>
+        </CardItem>
+        <CardItem title='메뉴 (완료)' className='overflow-auto'>
+        </CardItem>
+      </div>
+    </>
+  );
+}

--- a/src/components/Dashboard/RevenueGraph.jsx
+++ b/src/components/Dashboard/RevenueGraph.jsx
@@ -1,0 +1,11 @@
+import CardItem from '../share/CardItem';
+export default function RevenueGraph() {
+  return (
+    <>
+      <CardItem
+        title='이번달 매출 그래프'
+        className='overflow-auto h-full'
+      ></CardItem>
+    </>
+  );
+}

--- a/src/components/Dashboard/TodayReservations.jsx
+++ b/src/components/Dashboard/TodayReservations.jsx
@@ -1,0 +1,11 @@
+import CardItem from '../share/CardItem';
+export default function TodayReservations() {
+  return (
+    <>
+      <CardItem
+        title='오늘 예약'
+        className='w-1/3 overflow-auto h-11/12'
+      ></CardItem>
+    </>
+  );
+}

--- a/src/components/Orders/OrderStatusAll.jsx
+++ b/src/components/Orders/OrderStatusAll.jsx
@@ -1,0 +1,16 @@
+import CardItem from '../share/CardItem';
+export default function OrderStatusAll() {
+  return (
+    <div className='flex h-11/12 gap-2 w-full'>
+      <CardItem title='들어온 주문' className='w-1/3 overflow-auto'>
+        {/* item 추가 예정 */}
+      </CardItem>
+      <CardItem title='조리 중' className='w-1/3 overflow-auto'>
+        {/* item 추가 예정 */}
+      </CardItem>
+      <CardItem title='완료' className='w-1/3 overflow-auto'>
+        {/* item 추가 예정 */}
+      </CardItem>
+    </div>
+  );
+}

--- a/src/components/layout/SideBar.jsx
+++ b/src/components/layout/SideBar.jsx
@@ -1,5 +1,5 @@
 import { SIDEBAR_PATH } from '../../constants';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 export default function SideBar({ toggleSidebar }) {
   return (

--- a/src/components/share/CardItem.jsx
+++ b/src/components/share/CardItem.jsx
@@ -1,17 +1,10 @@
 import { twMerge } from 'tailwind-merge';
 
-export default function CardItem({ size = 'md', title, children, className }) {
+export default function CardItem({  title, children, className }) {
   const baseStyles =
-    'rounded-3xl shadow-sm bg-white border border-gray-100 transition-all duration-200 hover:shadow-lg';
+    'rounded-xl shadow-sm bg-white border border-gray-100 transition-all duration-200 p-2';
 
-  const sizeStyles = {
-    sm: 'p-4 h-24 text-sm max-w-xs',
-    md: 'p-4 h-36 text-base max-w-sm',
-    lg: 'p-4 h-48 max-w-md',
-    xl: 'p-4 h-60 text-xl max-w-lg',
-  };
-
-  const classes = twMerge(baseStyles, sizeStyles[size], className);
+  const classes = twMerge(baseStyles, className);
 
   return (
     <div className={classes}>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,7 +3,6 @@ export const SIDEBAR_PATH = [
   { path: '/orders', label: '주문관리' },
   { path: '/menus', label: '메뉴관리' },
   { path: '/reservations', label: '예약관리' },
-  { path: '/notifications', label: '알림관리' },
   { path: '/statistics', label: '매출통계' },
 ];
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,7 +3,6 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 
-
 // import files
 import './style/tailwind.css';
 import App from './App.jsx';
@@ -11,7 +10,6 @@ import Dashboard from './pages/Dashboard';
 import Orders from './pages/Orders';
 import Menus from './pages/Menus';
 import Reservations from './pages/Reservations';
-import Notifications from './pages/Notifications';
 import Statistics from './pages/Statistics';
 
 const router = createBrowserRouter([
@@ -34,10 +32,6 @@ const router = createBrowserRouter([
       {
         path: 'reservations',
         element: <Reservations />,
-      },
-      {
-        path: 'notifications',
-        element: <Notifications />,
       },
       {
         path: 'statistics',

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,8 +1,22 @@
-import CardItem from '../components/share/CardItem';
+import OrderStatus from '../components/Dashboard/OrderStatus';
+import RevenueGraph from '../components/Dashboard/RevenueGraph';
+import TodayReservations from '../components/Dashboard/TodayReservations';
+
+
 export default function Dashboard() {
   return (
-    <div>
-      <h1 className='text-2xl font-bold'>대시보드</h1>
+    <div className='flex h-screen p-2 gap-2'>
+      {/* 왼쪽 */}
+      <div className='flex-[1] flex flex-col gap-2 h-11/12'>
+        {/* 메뉴 영역 */}
+       <OrderStatus/>
+
+        {/* 매출 그래프 영역 */}
+       <RevenueGraph/>
+      </div>
+
+      {/* 오른쪽, 오늘 예약 */}
+      <TodayReservations/>
     </div>
   );
 }

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -12,7 +12,7 @@ export default function Main() {
 
   return (
     <div className='flex h-screen bg-gray-100'>
-      {/* Sidebar */}
+      {/* 사이드 바 */}
       <div
         className={`fixed inset-y-0 left-0 z-30 w-52 bg-gray-800 transform ${
           isSidebarOpen ? 'translate-x-0' : '-translate-x-full'
@@ -21,11 +21,11 @@ export default function Main() {
         <SideBar toggleSidebar={toggleSidebar} />
       </div>
 
-      {/* Main content */}
+      {/* 메인 콘텐츠 */}
       <div className='flex-1 flex flex-col overflow-hidden'>
         <Header toggleSidebar={toggleSidebar} />
-        <main className='flex-1 overflow-x-hidden overflow-y-auto bg-gray-100 p-4'>
-          <Outlet />
+        <main className='bg-gray-100'>
+          <Outlet/>
         </main>
       </div>
     </div>

--- a/src/pages/Notifications.jsx
+++ b/src/pages/Notifications.jsx
@@ -1,7 +1,0 @@
-export default function Notifications() {
-  return (
-    <div>
-      <h1 className='text-2xl font-bold'>Notifications</h1>
-    </div>
-  );
-}

--- a/src/pages/Orders.jsx
+++ b/src/pages/Orders.jsx
@@ -1,7 +1,8 @@
- export default function Orders(){
+import OrderStatusAll from '../components/Orders/OrderStatusAll';
+export default function Orders() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold">Orders</h1>
+    <div className='flex h-screen p-2'>
+      <OrderStatusAll/>
     </div>
   );
-};
+}


### PR DESCRIPTION
대시보드 섹션을 위한 OrderStatus, RevenueGraph, TodayReservations 컴포넌트와  전체 주문 상태 표시용 컴포넌트를 추가함. Dashboard와 Orders 페이지에서 해당 컴포넌트를 사용하도록 수정하고 레이아웃을 개선함. 알림(Notifications) 페이지와 관련 라우트 및 링크를 제거함.